### PR TITLE
[🌈 Feature] 경험 소개 페이지 구현

### DIFF
--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -103,6 +103,7 @@ const Styled = {
   `,
   Title: styled(CopyStyle.XLarge)`
     margin-right: 0.5rem;
+    line-height: 1.5;
     color: black;
   `,
   Period: styled.span`

--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -1,8 +1,8 @@
 import React, { MutableRefObject } from 'react';
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 
 import CopyStyle from '@components/Text';
-import { css } from '@emotion/react';
 
 export enum CardsState {
   invisible = 'invisible',

--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -1,26 +1,41 @@
-import CopyStyle from '@components/Text';
+import React, { MutableRefObject } from 'react';
 import styled from '@emotion/styled';
-import React from 'react';
+
+import CopyStyle from '@components/Text';
+import { css } from '@emotion/react';
+
+export enum CardsState {
+  invisible = 'invisible',
+  visible = 'visible',
+  out = 'out',
+}
+
+export type CardsStateValueType = keyof typeof CardsState;
 
 interface ExperienceCardProps {
   period: string;
   skills: string[];
   contents: string[];
+  state: CardsStateValueType;
 }
-const ExperienceCard = ({ period, skills, contents }: ExperienceCardProps) => {
+
+const ExperienceCard = (
+  { period, skills, contents, state }: ExperienceCardProps,
+  ref: MutableRefObject<HTMLElement>
+) => {
   return (
-    <Styled.Container>
-      <Styled.Title></Styled.Title>
+    <Styled.Container state={state}>
+      <Styled.Title>{state}</Styled.Title>
       <div>
         <CopyStyle.SubCopy>기간</CopyStyle.SubCopy>
         {period}
 
         <CopyStyle.SubCopy>사용기술</CopyStyle.SubCopy>
-        <Styled.List>
+        <Styled.Tags>
           {skills.map((skill) => (
             <Styled.Tag key={skill}>{skill}</Styled.Tag>
           ))}
-        </Styled.List>
+        </Styled.Tags>
 
         <CopyStyle.SubCopy>내용</CopyStyle.SubCopy>
         <Styled.List>
@@ -32,18 +47,54 @@ const ExperienceCard = ({ period, skills, contents }: ExperienceCardProps) => {
     </Styled.Container>
   );
 };
-
 const Styled = {
-  Container: styled.article`
-    width: 100%;
-    height: 100%;
-    padding: 2rem;
-    border: 1px solid #ddd;
+  Container: styled.article<{ state: CardsStateValueType }>`
+    position: absolute;
 
+    width: 500px;
+    height: 500px;
+
+    padding: 2rem;
+    color: black;
+    background: white;
+
+    border: 1px solid #fff;
     border-radius: 20px;
+    transition: all 1s;
+    transform: scale(0);
+
+    ${({ state }) => {
+      switch (state) {
+        case CardsState.invisible: {
+          return css`
+            opacity: 0;
+            transform: scale(0);
+          `;
+        }
+
+        case CardsState.visible: {
+          return css`
+            opacity: 1;
+            transform: scale(1);
+          `;
+        }
+
+        case CardsState.out: {
+          return css`
+            transition: transform 1s;
+            transform: translateZ(5400px) translateX(-100vw) scale(1);
+          `;
+        }
+
+        default: {
+          return '';
+        }
+      }
+    }}
   `,
   Title: styled(CopyStyle.MainCopy)`
     margin-bottom: 2rem;
+    color: black;
   `,
   List: styled.ul`
     padding: 0;
@@ -54,10 +105,16 @@ const Styled = {
     margin: 0;
     list-style: none;
   `,
+  Tags: styled.ul`
+    display: flex;
+    padding: 0;
+    margin: 0;
+  `,
   Tag: styled.div`
     padding: 0.5rem 0.75rem;
     background: #ddd;
     border-radius: 1rem;
   `,
 };
+
 export default ExperienceCard;

--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -17,30 +17,33 @@ interface ExperienceCardProps {
   skills: string[];
   contents: string[];
   state: CardsStateValueType;
+  title: string;
 }
 
 const ExperienceCard = (
-  { period, skills, contents, state }: ExperienceCardProps,
+  { period, skills, contents, state, title }: ExperienceCardProps,
   ref: MutableRefObject<HTMLElement>
 ) => {
   return (
     <Styled.Container state={state}>
-      <Styled.Title>{state}</Styled.Title>
+      <Styled.Header>
+        <Styled.Title>{title}</Styled.Title>
+        <Styled.Period>🗓 {period}</Styled.Period>
+      </Styled.Header>
       <div>
-        <CopyStyle.SubCopy>기간</CopyStyle.SubCopy>
-        {period}
-
-        <CopyStyle.SubCopy>사용기술</CopyStyle.SubCopy>
+        <Styled.SubCopy>사용기술</Styled.SubCopy>
         <Styled.Tags>
           {skills.map((skill) => (
             <Styled.Tag key={skill}>{skill}</Styled.Tag>
           ))}
         </Styled.Tags>
 
-        <CopyStyle.SubCopy>내용</CopyStyle.SubCopy>
+        <Styled.SubCopy>내용</Styled.SubCopy>
         <Styled.List>
           {contents.map((content) => (
-            <Styled.Description key={content}>{content}</Styled.Description>
+            <Styled.Description
+              key={content}
+            >{`- ${content}`}</Styled.Description>
           ))}
         </Styled.List>
       </div>
@@ -54,13 +57,12 @@ const Styled = {
     width: 500px;
     height: 500px;
 
-    padding: 2rem;
+    padding: 1rem 2rem;
     color: black;
     background: white;
 
     border: 1px solid #fff;
     border-radius: 20px;
-    transition: all 1s;
     transform: scale(0);
 
     ${({ state }) => {
@@ -68,6 +70,7 @@ const Styled = {
         case CardsState.invisible: {
           return css`
             opacity: 0;
+            transition: transform 1s;
             transform: scale(0);
           `;
         }
@@ -75,12 +78,14 @@ const Styled = {
         case CardsState.visible: {
           return css`
             opacity: 1;
+            transition: transform 1s;
             transform: scale(1);
           `;
         }
 
         case CardsState.out: {
           return css`
+            opacity: 1;
             transition: transform 1s;
             transform: translateZ(5400px) translateX(-100vw) scale(1);
           `;
@@ -92,9 +97,24 @@ const Styled = {
       }
     }}
   `,
-  Title: styled(CopyStyle.MainCopy)`
-    margin-bottom: 2rem;
+  Header: styled.header`
+    display: flex;
+    align-items: baseline;
+  `,
+  Title: styled(CopyStyle.XLarge)`
+    margin-right: 0.5rem;
     color: black;
+  `,
+  Period: styled.span`
+    color: #888;
+  `,
+  SubCopy: styled(CopyStyle.Default)`
+    font-weight: bold;
+    color: black;
+
+    &:not(:first-child) {
+      margin-top: 1rem;
+    }
   `,
   List: styled.ul`
     padding: 0;
@@ -102,17 +122,22 @@ const Styled = {
   `,
   Description: styled.li`
     padding: 0;
-    margin: 0;
+    margin: 0.25rem 0;
     list-style: none;
   `,
   Tags: styled.ul`
     display: flex;
+    flex-wrap: wrap;
     padding: 0;
     margin: 0;
   `,
   Tag: styled.div`
-    padding: 0.5rem 0.75rem;
-    background: #ddd;
+    flex-shrink: 0;
+    padding: 0.25rem 0.75rem;
+    margin: 0.125rem;
+    font-size: 0.75rem;
+    color: white;
+    background: #333;
     border-radius: 1rem;
   `,
 };

--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -63,6 +63,8 @@ const Styled = {
 
     border: 1px solid #fff;
     border-radius: 20px;
+
+    transition: all 1s;
     transform: scale(0);
 
     ${({ state }) => {
@@ -70,7 +72,6 @@ const Styled = {
         case CardsState.invisible: {
           return css`
             opacity: 0;
-            transition: transform 1s;
             transform: scale(0);
           `;
         }
@@ -78,7 +79,6 @@ const Styled = {
         case CardsState.visible: {
           return css`
             opacity: 1;
-            transition: transform 1s;
             transform: scale(1);
           `;
         }
@@ -86,7 +86,6 @@ const Styled = {
         case CardsState.out: {
           return css`
             opacity: 1;
-            transition: transform 1s;
             transform: translateZ(5400px) translateX(-100vw) scale(1);
           `;
         }
@@ -99,6 +98,7 @@ const Styled = {
   `,
   Header: styled.header`
     display: flex;
+    flex-direction: column;
     align-items: baseline;
   `,
   Title: styled(CopyStyle.XLarge)`
@@ -109,12 +109,9 @@ const Styled = {
     color: #888;
   `,
   SubCopy: styled(CopyStyle.Default)`
+    margin-top: 1rem;
     font-weight: bold;
     color: black;
-
-    &:not(:first-child) {
-      margin-top: 1rem;
-    }
   `,
   List: styled.ul`
     padding: 0;

--- a/components/Card/Experience.tsx
+++ b/components/Card/Experience.tsx
@@ -1,0 +1,63 @@
+import CopyStyle from '@components/Text';
+import styled from '@emotion/styled';
+import React from 'react';
+
+interface ExperienceCardProps {
+  period: string;
+  skills: string[];
+  contents: string[];
+}
+const ExperienceCard = ({ period, skills, contents }: ExperienceCardProps) => {
+  return (
+    <Styled.Container>
+      <Styled.Title></Styled.Title>
+      <div>
+        <CopyStyle.SubCopy>기간</CopyStyle.SubCopy>
+        {period}
+
+        <CopyStyle.SubCopy>사용기술</CopyStyle.SubCopy>
+        <Styled.List>
+          {skills.map((skill) => (
+            <Styled.Tag key={skill}>{skill}</Styled.Tag>
+          ))}
+        </Styled.List>
+
+        <CopyStyle.SubCopy>내용</CopyStyle.SubCopy>
+        <Styled.List>
+          {contents.map((content) => (
+            <Styled.Description key={content}>{content}</Styled.Description>
+          ))}
+        </Styled.List>
+      </div>
+    </Styled.Container>
+  );
+};
+
+const Styled = {
+  Container: styled.article`
+    width: 100%;
+    height: 100%;
+    padding: 2rem;
+    border: 1px solid #ddd;
+
+    border-radius: 20px;
+  `,
+  Title: styled(CopyStyle.MainCopy)`
+    margin-bottom: 2rem;
+  `,
+  List: styled.ul`
+    padding: 0;
+    margin: 0;
+  `,
+  Description: styled.li`
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  `,
+  Tag: styled.div`
+    padding: 0.5rem 0.75rem;
+    background: #ddd;
+    border-radius: 1rem;
+  `,
+};
+export default ExperienceCard;

--- a/components/Card/index.ts
+++ b/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { default as ExperienceCard } from './Experience';

--- a/components/Text/TransitionText.tsx
+++ b/components/Text/TransitionText.tsx
@@ -1,6 +1,7 @@
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+
 import useIntersectionObserver, {
   UseIntersectionCallbackType,
 } from '@hooks/useIntersectionObserver';
@@ -35,6 +36,7 @@ const sizes = {
   lg: '1.5rem',
   xl: '2rem',
   xxl: '4rem',
+  xxxl: '10rem',
 } as const;
 
 const Text = styled.div<TextInterface>`

--- a/components/layouts/BaseLayout.tsx
+++ b/components/layouts/BaseLayout.tsx
@@ -1,6 +1,6 @@
-import { BaseHeader } from '@components/Header';
-import styled from '@emotion/styled';
 import React, { ReactElement } from 'react';
+
+import { BaseHeader } from '@components/Header';
 
 import { LayoutInterface } from './types';
 

--- a/components/layouts/BaseLayout.tsx
+++ b/components/layouts/BaseLayout.tsx
@@ -1,4 +1,5 @@
 import { BaseHeader } from '@components/Header';
+import styled from '@emotion/styled';
 import React, { ReactElement } from 'react';
 
 import { LayoutInterface } from './types';

--- a/components/layouts/IntroLayout.tsx
+++ b/components/layouts/IntroLayout.tsx
@@ -1,5 +1,5 @@
 import { IntroHeader } from '@components/Header';
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 import { LayoutInterface } from './types';
 
 const IntroLayout = ({ children }: LayoutInterface) => {

--- a/hooks/useCanvas.ts
+++ b/hooks/useCanvas.ts
@@ -3,7 +3,6 @@ import {
   MutableRefObject,
   SetStateAction,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -9,15 +9,13 @@ const useIntersectionObserver = (
 ) => {
   useEffect(() => {
     if (callbackRef.current === null || targetRef.current === null) return;
-
     const target = targetRef.current;
-    const options = {
-      root,
-      rootMargin: `0px 0px -300px 0px`,
-      threshold,
-    };
 
-    const observer = new IntersectionObserver(callbackRef.current, options);
+    const observer = new IntersectionObserver(callbackRef.current, {
+      root,
+      rootMargin,
+      threshold,
+    });
 
     observer.observe(target);
 

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -55,30 +55,109 @@ const ExpriencePage = () => {
     });
   };
 
+  const dataset = [
+    {
+      id: 0,
+      type: '프로젝트',
+      title: '웹 포트폴리오 사이트',
+      period: {
+        start: '2022.10',
+        end: '현재',
+      },
+      skills: [
+        'Next.js',
+        'React',
+        'husky',
+        'Github Action',
+        '@emotion',
+        'TypeScript',
+        'AWS(S3, Route 53, CloudFront)',
+        'yarn berry',
+        'Canvas API',
+      ],
+      contents: [
+        'SSG 기반 웹 포트폴리오 사이트 구축',
+        '`Canvas API`로 메타볼 애니메이션 구현',
+        '`translate3d`로 스크롤 시 3D 효과 구현',
+        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
+        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
+        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+      ],
+    },
+    {
+      id: 1,
+      type: '프로젝트',
+      title: '웹 포트폴리오 사이트',
+      period: {
+        start: '2022.10',
+        end: '현재',
+      },
+      skills: [
+        'Next.js',
+        'React',
+        'husky',
+        'Github Action',
+        '@emotion',
+        'TypeScript',
+        'AWS(S3, Route 53, CloudFront)',
+        'yarn berry',
+        'Canvas API',
+      ],
+      contents: [
+        'SSG 기반 웹 포트폴리오 사이트 구축',
+        '`Canvas API`로 메타볼 애니메이션 구현',
+        '`translate3d`로 스크롤 시 3D 효과 구현',
+        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
+        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
+        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+      ],
+    },
+    {
+      id: 2,
+      type: '프로젝트',
+      title: '웹 포트폴리오 사이트 구현',
+      period: {
+        start: '2022.10',
+        end: '현재',
+      },
+      skills: [
+        'Next.js',
+        'React',
+        'husky',
+        'Github Action',
+        '@emotion',
+        'TypeScript',
+        'AWS(S3, Route 53, CloudFront)',
+        'yarn berry',
+        'Canvas API',
+      ],
+      contents: [
+        'SSG 기반 웹 포트폴리오 사이트 구축',
+        '`Canvas API`로 메타볼 애니메이션 구현',
+        '`translate3d`로 스크롤 시 3D 효과 구현',
+        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
+        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
+        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+      ],
+    },
+  ];
+
   useIntersectionObserver(cardRefs[0], useCallbackRef(0), { threshold: 0.5 });
   useIntersectionObserver(cardRefs[1], useCallbackRef(1), { threshold: 0.5 });
   useIntersectionObserver(cardRefs[2], useCallbackRef(2), { threshold: 0.5 });
   return (
     <>
       <Styled.Scene>
-        <ExperienceCard
-          state={cardsState[0]}
-          period={new Date().toLocaleDateString()}
-          skills={['hello!']}
-          contents={['1', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
-        ></ExperienceCard>
-        <ExperienceCard
-          state={cardsState[1]}
-          period={new Date().toLocaleDateString()}
-          skills={['hello!']}
-          contents={['2', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
-        ></ExperienceCard>
-        <ExperienceCard
-          state={cardsState[2]}
-          period={new Date().toLocaleDateString()}
-          skills={['hello!']}
-          contents={['3', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
-        ></ExperienceCard>
+        {dataset.map((data) => (
+          <ExperienceCard
+            key={data.id}
+            title={data.title}
+            state={cardsState[data.id]}
+            period={`${data.period.start} ~ ${data.period.end}`}
+            skills={data.skills}
+            contents={data.contents}
+          ></ExperienceCard>
+        ))}
       </Styled.Scene>
       <Styled.Container>
         <Styled.IntersectionTarget

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -1,9 +1,98 @@
+import { ExperienceCard } from '@components/Card';
+import { CardsState, CardsStateValueType } from '@components/Card/Experience';
 import { getBaseLayout } from '@components/layouts';
 import styled from '@emotion/styled';
-import React from 'react';
+import useIntersectionObserver from '@hooks/useIntersectionObserver';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 const ExpriencePage = () => {
-  return <Styled.Container>ExpriencePage</Styled.Container>;
+  const [cardsState, setCardsState] = useState<CardsStateValueType[]>([
+    CardsState.invisible,
+    CardsState.invisible,
+    CardsState.invisible,
+  ]);
+
+  const cardRefs = [useRef(null), useRef(null), useRef(null)];
+  const lastIntersecting = useRef(0);
+
+  /**
+   * [x] 카드의 상태를 업데이트하는 함수를 만든다.
+   * TODO: 겹칠 경우
+   * [x] 만약 inivisible이었으면 겹칠 경우 visible로 바꿔준다.
+   * [x] 만약 out이었으면 겹칠 경우 visible으로 바꿔준다.
+   
+   * TODO: 겹치지 않았을 경우
+   * [x] 만약 visible이었다면 out으로 바꿔준다.
+   * [x] 이때, 스크롤을 위로 올리면 invisible이 되도록 한다.
+   * [x] 이를 구현하기 위해, window.scrollY는 리플로우를 유발하므로 다른 방법을 고안한다. useRef를 이용하여 마지막 겹친 인덱스를 캐싱한다. 
+   * [x] 다행히도 intersectionAPI는 스크롤에 대한 교차 시 호출 로직이 스크롤 방향에 따라 일정하다. 이를 이용하자.
+   */
+  const updateState =
+    (idx: number, entry: IntersectionObserverEntry) =>
+    (value: CardsStateValueType, cardsIndex: number) => {
+      if (idx !== cardsIndex) return value;
+
+      if (entry.isIntersecting) {
+        lastIntersecting.current = idx;
+
+        return CardsState.visible;
+      } else {
+        if (value === CardsState.visible) {
+          return lastIntersecting.current >= idx
+            ? CardsState.out
+            : CardsState.invisible;
+        }
+      }
+
+      return value;
+    };
+
+  const useCallbackRef = (idx: number) => {
+    return useRef<IntersectionObserverCallback>((entries) => {
+      entries.forEach((entry) => {
+        setCardsState((state) => state.map(updateState(idx, entry)));
+      });
+    });
+  };
+
+  useIntersectionObserver(cardRefs[0], useCallbackRef(0), { threshold: 0.5 });
+  useIntersectionObserver(cardRefs[1], useCallbackRef(1), { threshold: 0.5 });
+  useIntersectionObserver(cardRefs[2], useCallbackRef(2), { threshold: 0.5 });
+  return (
+    <>
+      <Styled.Scene>
+        <ExperienceCard
+          state={cardsState[0]}
+          period={new Date().toLocaleDateString()}
+          skills={['hello!']}
+          contents={['1', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
+        ></ExperienceCard>
+        <ExperienceCard
+          state={cardsState[1]}
+          period={new Date().toLocaleDateString()}
+          skills={['hello!']}
+          contents={['2', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
+        ></ExperienceCard>
+        <ExperienceCard
+          state={cardsState[2]}
+          period={new Date().toLocaleDateString()}
+          skills={['hello!']}
+          contents={['3', '테스트 중이에요!', '카드를 테스트하고 있습니다.']}
+        ></ExperienceCard>
+      </Styled.Scene>
+      <Styled.Container>
+        <Styled.IntersectionTarget
+          ref={cardRefs[0]}
+        ></Styled.IntersectionTarget>
+        <Styled.IntersectionTarget
+          ref={cardRefs[1]}
+        ></Styled.IntersectionTarget>
+        <Styled.IntersectionTarget
+          ref={cardRefs[2]}
+        ></Styled.IntersectionTarget>
+      </Styled.Container>
+    </>
+  );
 };
 
 ExpriencePage.getLayout = getBaseLayout;
@@ -11,9 +100,25 @@ ExpriencePage.getLayout = getBaseLayout;
 const Styled = {
   Container: styled.section`
     width: 100%;
+    height: 1600vh;
+    /* padding-top: 4rem; */
+    perspective: 10000px;
+  `,
+  IntersectionTarget: styled.div`
+    width: 100%;
     height: 100vh;
-
-    padding-top: 4rem;
+  `,
+  Scene: styled.section`
+    position: fixed;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100vh;
+    perspective: 10000px;
   `,
 };
 

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -1,18 +1,31 @@
+import React, { useRef, useState } from 'react';
+import styled from '@emotion/styled';
+
 import { ExperienceCard } from '@components/Card';
 import { CardsState, CardsStateValueType } from '@components/Card/Experience';
 import { getBaseLayout } from '@components/layouts';
-import styled from '@emotion/styled';
+
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 const ExpriencePage = () => {
   const [cardsState, setCardsState] = useState<CardsStateValueType[]>([
     CardsState.invisible,
     CardsState.invisible,
     CardsState.invisible,
+    CardsState.invisible,
+    CardsState.invisible,
+    CardsState.invisible,
   ]);
 
-  const cardRefs = [useRef(null), useRef(null), useRef(null)];
+  const cardRefs = [
+    useRef(null),
+    useRef(null),
+    useRef(null),
+    useRef(null),
+    useRef(null),
+    useRef(null),
+  ];
+
   const lastIntersecting = useRef(0);
 
   /**
@@ -84,60 +97,89 @@ const ExpriencePage = () => {
         '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
       ],
     },
+
     {
       id: 1,
       type: '프로젝트',
-      title: '웹 포트폴리오 사이트',
+      title: 'JS, React 유틸 라이브러리',
       period: {
-        start: '2022.10',
+        start: '2022.08',
         end: '현재',
       },
-      skills: [
-        'Next.js',
-        'React',
-        'husky',
-        'Github Action',
-        '@emotion',
-        'TypeScript',
-        'AWS(S3, Route 53, CloudFront)',
-        'yarn berry',
-        'Canvas API',
-      ],
+      skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
       contents: [
-        'SSG 기반 웹 포트폴리오 사이트 구축',
-        '`Canvas API`로 메타볼 애니메이션 구현',
-        '`translate3d`로 스크롤 시 3D 효과 구현',
-        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
-        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
-        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+        '재사용 가능한 애니메이션 및 유틸 라이브러리 제작.',
+        '캘린더 컴포넌트 구현, `Todo` 쌓이는 로직 최적화',
+        'Mobile App처럼 라우트 이동 전환 효과가 나오도록 하는 `Router Component` 구현',
+        '`Three.js`로 3D 터널 애니메이션 구현',
+        '`yarn`으로 다양한 환경에서의 구현을 분리하고 관리하고자 모노레포 구축',
       ],
     },
+
     {
       id: 2,
-      type: '프로젝트',
-      title: '웹 포트폴리오 사이트 구현',
+      type: '스터디',
+      title: '자바스크립트 스터디',
       period: {
-        start: '2022.10',
+        start: '2022.08',
+        end: '2022.11',
+      },
+      skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
+      contents: [
+        '모던 자바스크립트 Deep Dive를 기반으로 4개월 간 진행',
+        'Git 관리 전략 설계 및 문서화, 이슈 및 PR Template을 제작하여 자유로운 논의 제안',
+        '중간 과제를 통해 배운 지식들을 응용하는 문화 제안 및 조성',
+        '주마다 Tech Blog에 탐구한 지식들 정리하여 게재',
+      ],
+    },
+
+    {
+      id: 3,
+      type: '프로젝트',
+      title: 'Vue 디자인 시스템 구축',
+      period: {
+        start: '2022.05',
         end: '현재',
       },
-      skills: [
-        'Next.js',
-        'React',
-        'husky',
-        'Github Action',
-        '@emotion',
-        'TypeScript',
-        'AWS(S3, Route 53, CloudFront)',
-        'yarn berry',
-        'Canvas API',
-      ],
+      skills: ['Vue3', 'Storybook'],
       contents: [
-        'SSG 기반 웹 포트폴리오 사이트 구축',
-        '`Canvas API`로 메타볼 애니메이션 구현',
-        '`translate3d`로 스크롤 시 3D 효과 구현',
-        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
-        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
-        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+        'Storybook으로 재사용, 테스트 가능한 컴포넌트 제작',
+        'Carousel, Menu 등의 컴포넌트 구현',
+        '복사, 입력, 삭제에 있어 커서 전환이 자연스러운 Formatter Input 컴포넌트 구현',
+      ],
+    },
+
+    {
+      id: 4,
+      type: '스터디',
+      title: '알고리즘 스터디',
+      period: {
+        start: '2021.09',
+        end: '현재',
+      },
+      skills: ['Vue3', 'Storybook'],
+      contents: [
+        '프로그래머스 팀원들과 알고리즘 스터디 진행',
+        '프로그래머스 기준 Lv1 ~ Lv4까지 진행 중',
+        '현재까지도 진행 중이며, 개발 경험도 함께 공유하며 성장 중',
+      ],
+    },
+
+    {
+      id: 5,
+      type: '교육',
+      title:
+        '프로그래머스 K-Digital Training 프론트엔드 엔지니어링 데브코스 1기',
+      period: {
+        start: '2021.09',
+        end: '현재',
+      },
+      skills: ['Vue3', 'Storybook'],
+      contents: [
+        '이벤트 애플리케이션 개발(Everevent)',
+        '11월 배움 기록왕 선정',
+        '모각코 애플리케이션 개발(달리는 모각코)',
+        '8월 이달의 스피커 선정',
       ],
     },
   ];
@@ -145,6 +187,10 @@ const ExpriencePage = () => {
   useIntersectionObserver(cardRefs[0], useCallbackRef(0), { threshold: 0.5 });
   useIntersectionObserver(cardRefs[1], useCallbackRef(1), { threshold: 0.5 });
   useIntersectionObserver(cardRefs[2], useCallbackRef(2), { threshold: 0.5 });
+  useIntersectionObserver(cardRefs[3], useCallbackRef(3), { threshold: 0.5 });
+  useIntersectionObserver(cardRefs[4], useCallbackRef(4), { threshold: 0.5 });
+  useIntersectionObserver(cardRefs[5], useCallbackRef(5), { threshold: 0.5 });
+
   return (
     <>
       <Styled.Scene>
@@ -169,6 +215,15 @@ const ExpriencePage = () => {
         <Styled.IntersectionTarget
           ref={cardRefs[2]}
         ></Styled.IntersectionTarget>
+        <Styled.IntersectionTarget
+          ref={cardRefs[3]}
+        ></Styled.IntersectionTarget>
+        <Styled.IntersectionTarget
+          ref={cardRefs[4]}
+        ></Styled.IntersectionTarget>
+        <Styled.IntersectionTarget
+          ref={cardRefs[5]}
+        ></Styled.IntersectionTarget>
       </Styled.Container>
     </>
   );
@@ -184,6 +239,9 @@ const Styled = {
     perspective: 10000px;
   `,
   IntersectionTarget: styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: 100%;
     height: 100vh;
   `,

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -1,0 +1,19 @@
+import { getBaseLayout } from '@components/layouts';
+import styled from '@emotion/styled';
+import React from 'react';
+
+const ExpriencePage = () => {
+  return <Styled.Container>ExpriencePage</Styled.Container>;
+};
+
+ExpriencePage.getLayout = getBaseLayout;
+
+const Styled = {
+  Container: styled.section`
+    width: 100%;
+    height: 100vh;
+
+    padding-top: 4rem;
+  `,
+};
+export default ExpriencePage;

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -1,12 +1,4 @@
-import React, {
-  createRef,
-  MutableRefObject,
-  RefObject,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { createRef, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { ExperienceCard } from '@components/Card';
@@ -246,7 +238,6 @@ const Styled = {
   Container: styled.section`
     width: 100%;
     height: 1600vh;
-    /* padding-top: 4rem; */
     perspective: 10000px;
   `,
   IntersectionTarget: styled.div`

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -1,4 +1,12 @@
-import React, { useRef, useState } from 'react';
+import React, {
+  createRef,
+  MutableRefObject,
+  RefObject,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import styled from '@emotion/styled';
 
 import { ExperienceCard } from '@components/Card';
@@ -7,39 +15,141 @@ import { getBaseLayout } from '@components/layouts';
 
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 
-const ExpriencePage = () => {
-  const [cardsState, setCardsState] = useState<CardsStateValueType[]>([
-    CardsState.invisible,
-    CardsState.invisible,
-    CardsState.invisible,
-    CardsState.invisible,
-    CardsState.invisible,
-    CardsState.invisible,
-  ]);
+const dataset = [
+  {
+    id: 0,
+    type: '프로젝트',
+    title: '웹 포트폴리오 사이트',
+    period: {
+      start: '2022.10',
+      end: '현재',
+    },
+    skills: [
+      'Next.js',
+      'React',
+      'husky',
+      'Github Action',
+      '@emotion',
+      'TypeScript',
+      'AWS(S3, Route 53, CloudFront)',
+      'yarn berry',
+      'Canvas API',
+    ],
+    contents: [
+      'SSG 기반 웹 포트폴리오 사이트 구축',
+      '`Canvas API`로 메타볼 애니메이션 구현',
+      '`translate3d`로 스크롤 시 3D 효과 구현',
+      'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
+      '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
+      '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
+    ],
+  },
 
-  const cardRefs = [
-    useRef(null),
-    useRef(null),
-    useRef(null),
-    useRef(null),
-    useRef(null),
-    useRef(null),
-  ];
+  {
+    id: 1,
+    type: '프로젝트',
+    title: 'JS, React 유틸 라이브러리',
+    period: {
+      start: '2022.08',
+      end: '현재',
+    },
+    skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
+    contents: [
+      '재사용 가능한 애니메이션 및 유틸 라이브러리 제작.',
+      '캘린더 컴포넌트 구현, `Todo` 쌓이는 로직 최적화',
+      'Mobile App처럼 라우트 이동 전환 효과가 나오도록 하는 `Router Component` 구현',
+      '`Three.js`로 3D 터널 애니메이션 구현',
+      '`yarn`으로 다양한 환경에서의 구현을 분리하고 관리하고자 모노레포 구축',
+    ],
+  },
+
+  {
+    id: 2,
+    type: '스터디',
+    title: '자바스크립트 스터디',
+    period: {
+      start: '2022.08',
+      end: '2022.11',
+    },
+    skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
+    contents: [
+      '모던 자바스크립트 Deep Dive를 기반으로 4개월 간 진행',
+      'Git 관리 전략 설계 및 문서화, 이슈 및 PR Template을 제작하여 자유로운 논의 제안',
+      '중간 과제를 통해 배운 지식들을 응용하는 문화 제안 및 조성',
+      '주마다 Tech Blog에 탐구한 지식들 정리하여 게재',
+    ],
+  },
+
+  {
+    id: 3,
+    type: '프로젝트',
+    title: 'Vue 디자인 시스템 구축',
+    period: {
+      start: '2022.05',
+      end: '현재',
+    },
+    skills: ['Vue3', 'Storybook'],
+    contents: [
+      'Storybook으로 재사용, 테스트 가능한 컴포넌트 제작',
+      'Carousel, Menu 등의 컴포넌트 구현',
+      '복사, 입력, 삭제에 있어 커서 전환이 자연스러운 Formatter Input 컴포넌트 구현',
+    ],
+  },
+
+  {
+    id: 4,
+    type: '스터디',
+    title: '알고리즘 스터디',
+    period: {
+      start: '2021.09',
+      end: '현재',
+    },
+    skills: ['Vanilla JS'],
+    contents: [
+      '프로그래머스 팀원들과 알고리즘 스터디 진행',
+      '프로그래머스 기준 Lv1 ~ Lv4까지 진행 중',
+      '현재까지도 진행 중이며, 개발 경험도 함께 공유하며 성장 중',
+    ],
+  },
+
+  {
+    id: 5,
+    type: '교육',
+    title: '프로그래머스 K-Digital Training 프론트엔드 엔지니어링 데브코스 1기',
+    period: {
+      start: '2021.07',
+      end: '2021.11',
+    },
+    skills: [
+      'HTML5',
+      'CSS3',
+      'VanillaJS',
+      'React',
+      'Vue',
+      'Next.js',
+      'Redux',
+      'Storybook',
+      'D3.js',
+    ],
+    contents: [
+      '이벤트 애플리케이션 개발(Everevent)',
+      '11월 배움 기록왕 선정',
+      '모각코 애플리케이션 개발(달리는 모각코)',
+      '8월 이달의 스피커 선정',
+    ],
+  },
+];
+
+const ExpriencePage = () => {
+  const [cardsState, setCardsState] = useState<CardsStateValueType[]>(
+    new Array(dataset.length).fill(CardsState.invisible)
+  );
+
+  const cardRefs = React.useRef([]);
+  cardRefs.current = dataset.map((_, i) => cardRefs.current[i] ?? createRef());
 
   const lastIntersecting = useRef(0);
 
-  /**
-   * [x] 카드의 상태를 업데이트하는 함수를 만든다.
-   * TODO: 겹칠 경우
-   * [x] 만약 inivisible이었으면 겹칠 경우 visible로 바꿔준다.
-   * [x] 만약 out이었으면 겹칠 경우 visible으로 바꿔준다.
-   
-   * TODO: 겹치지 않았을 경우
-   * [x] 만약 visible이었다면 out으로 바꿔준다.
-   * [x] 이때, 스크롤을 위로 올리면 invisible이 되도록 한다.
-   * [x] 이를 구현하기 위해, window.scrollY는 리플로우를 유발하므로 다른 방법을 고안한다. useRef를 이용하여 마지막 겹친 인덱스를 캐싱한다. 
-   * [x] 다행히도 intersectionAPI는 스크롤에 대한 교차 시 호출 로직이 스크롤 방향에 따라 일정하다. 이를 이용하자.
-   */
   const updateState =
     (idx: number, entry: IntersectionObserverEntry) =>
     (value: CardsStateValueType, cardsIndex: number) => {
@@ -68,128 +178,40 @@ const ExpriencePage = () => {
     });
   };
 
-  const dataset = [
-    {
-      id: 0,
-      type: '프로젝트',
-      title: '웹 포트폴리오 사이트',
-      period: {
-        start: '2022.10',
-        end: '현재',
-      },
-      skills: [
-        'Next.js',
-        'React',
-        'husky',
-        'Github Action',
-        '@emotion',
-        'TypeScript',
-        'AWS(S3, Route 53, CloudFront)',
-        'yarn berry',
-        'Canvas API',
-      ],
-      contents: [
-        'SSG 기반 웹 포트폴리오 사이트 구축',
-        '`Canvas API`로 메타볼 애니메이션 구현',
-        '`translate3d`로 스크롤 시 3D 효과 구현',
-        'CICD를 통한 린트, 배포, 릴리즈 노트 자동화 적용',
-        '`Compound Composite` 디자인 패턴, `Custom Hook` 패턴 적용',
-        '`yarn berry`를 통한 `zero install`로 빌드 및 배포 시간 단축',
-      ],
-    },
+  /**
+   * NOTE: 이건 바꾸면 문제가 발생하므로 데이터가 바뀐다면 계속해서 개수가 바뀐만큼 추가해주어야 한다. 헷갈리지 않도록 넘버링을 한다.
+   * 만약 에러가 나온다면, 여기일 확률이 높으므로 먼저 확인한다.
+   */
 
-    {
-      id: 1,
-      type: '프로젝트',
-      title: 'JS, React 유틸 라이브러리',
-      period: {
-        start: '2022.08',
-        end: '현재',
-      },
-      skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
-      contents: [
-        '재사용 가능한 애니메이션 및 유틸 라이브러리 제작.',
-        '캘린더 컴포넌트 구현, `Todo` 쌓이는 로직 최적화',
-        'Mobile App처럼 라우트 이동 전환 효과가 나오도록 하는 `Router Component` 구현',
-        '`Three.js`로 3D 터널 애니메이션 구현',
-        '`yarn`으로 다양한 환경에서의 구현을 분리하고 관리하고자 모노레포 구축',
-      ],
-    },
+  // 1
+  useIntersectionObserver(cardRefs.current[0], useCallbackRef(0), {
+    threshold: 0.5,
+  });
 
-    {
-      id: 2,
-      type: '스터디',
-      title: '자바스크립트 스터디',
-      period: {
-        start: '2022.08',
-        end: '2022.11',
-      },
-      skills: ['Vanilla JS', 'React', 'Three.js', 'yarn berry'],
-      contents: [
-        '모던 자바스크립트 Deep Dive를 기반으로 4개월 간 진행',
-        'Git 관리 전략 설계 및 문서화, 이슈 및 PR Template을 제작하여 자유로운 논의 제안',
-        '중간 과제를 통해 배운 지식들을 응용하는 문화 제안 및 조성',
-        '주마다 Tech Blog에 탐구한 지식들 정리하여 게재',
-      ],
-    },
+  // 2
+  useIntersectionObserver(cardRefs.current[1], useCallbackRef(1), {
+    threshold: 0.5,
+  });
 
-    {
-      id: 3,
-      type: '프로젝트',
-      title: 'Vue 디자인 시스템 구축',
-      period: {
-        start: '2022.05',
-        end: '현재',
-      },
-      skills: ['Vue3', 'Storybook'],
-      contents: [
-        'Storybook으로 재사용, 테스트 가능한 컴포넌트 제작',
-        'Carousel, Menu 등의 컴포넌트 구현',
-        '복사, 입력, 삭제에 있어 커서 전환이 자연스러운 Formatter Input 컴포넌트 구현',
-      ],
-    },
+  // 3
+  useIntersectionObserver(cardRefs.current[2], useCallbackRef(2), {
+    threshold: 0.5,
+  });
 
-    {
-      id: 4,
-      type: '스터디',
-      title: '알고리즘 스터디',
-      period: {
-        start: '2021.09',
-        end: '현재',
-      },
-      skills: ['Vue3', 'Storybook'],
-      contents: [
-        '프로그래머스 팀원들과 알고리즘 스터디 진행',
-        '프로그래머스 기준 Lv1 ~ Lv4까지 진행 중',
-        '현재까지도 진행 중이며, 개발 경험도 함께 공유하며 성장 중',
-      ],
-    },
+  // 4
+  useIntersectionObserver(cardRefs.current[3], useCallbackRef(3), {
+    threshold: 0.5,
+  });
 
-    {
-      id: 5,
-      type: '교육',
-      title:
-        '프로그래머스 K-Digital Training 프론트엔드 엔지니어링 데브코스 1기',
-      period: {
-        start: '2021.09',
-        end: '현재',
-      },
-      skills: ['Vue3', 'Storybook'],
-      contents: [
-        '이벤트 애플리케이션 개발(Everevent)',
-        '11월 배움 기록왕 선정',
-        '모각코 애플리케이션 개발(달리는 모각코)',
-        '8월 이달의 스피커 선정',
-      ],
-    },
-  ];
+  // 5
+  useIntersectionObserver(cardRefs.current[4], useCallbackRef(4), {
+    threshold: 0.5,
+  });
 
-  useIntersectionObserver(cardRefs[0], useCallbackRef(0), { threshold: 0.5 });
-  useIntersectionObserver(cardRefs[1], useCallbackRef(1), { threshold: 0.5 });
-  useIntersectionObserver(cardRefs[2], useCallbackRef(2), { threshold: 0.5 });
-  useIntersectionObserver(cardRefs[3], useCallbackRef(3), { threshold: 0.5 });
-  useIntersectionObserver(cardRefs[4], useCallbackRef(4), { threshold: 0.5 });
-  useIntersectionObserver(cardRefs[5], useCallbackRef(5), { threshold: 0.5 });
+  // 6
+  useIntersectionObserver(cardRefs.current[5], useCallbackRef(5), {
+    threshold: 0.5,
+  });
 
   return (
     <>
@@ -205,25 +227,14 @@ const ExpriencePage = () => {
           ></ExperienceCard>
         ))}
       </Styled.Scene>
+
       <Styled.Container>
-        <Styled.IntersectionTarget
-          ref={cardRefs[0]}
-        ></Styled.IntersectionTarget>
-        <Styled.IntersectionTarget
-          ref={cardRefs[1]}
-        ></Styled.IntersectionTarget>
-        <Styled.IntersectionTarget
-          ref={cardRefs[2]}
-        ></Styled.IntersectionTarget>
-        <Styled.IntersectionTarget
-          ref={cardRefs[3]}
-        ></Styled.IntersectionTarget>
-        <Styled.IntersectionTarget
-          ref={cardRefs[4]}
-        ></Styled.IntersectionTarget>
-        <Styled.IntersectionTarget
-          ref={cardRefs[5]}
-        ></Styled.IntersectionTarget>
+        {dataset.map((data, i) => (
+          <Styled.IntersectionTarget
+            key={data.id}
+            ref={cardRefs.current[i]}
+          ></Styled.IntersectionTarget>
+        ))}
       </Styled.Container>
     </>
   );

--- a/pages/experiences/index.tsx
+++ b/pages/experiences/index.tsx
@@ -16,4 +16,5 @@ const Styled = {
     padding-top: 4rem;
   `,
 };
+
 export default ExpriencePage;


### PR DESCRIPTION
## 🚀 설명

경험 기술 페이지를 구현했다!
다음과 같이 일정 부분 스크롤하면 나오고, 만약 미달되면 다시 들어가는 효과를 구현했다.

https://user-images.githubusercontent.com/78713176/199009055-d95e99d9-eb56-477c-9e9c-6a61a2065bd6.mov


https://user-images.githubusercontent.com/78713176/199009266-f0f92525-b257-4260-877f-3e67453442c1.mov


## 🔗 관련 이슈와 링크

#28 

## 🔥 논의해 볼 사항

### 중복되는 코드로직 수정 일부 불가

`useIntersectionObserver`의 경우 반복문을 사용할 수 없다. `useRef`가 동적으로 추가된다는 것을 리액트에서 허용하지 않기 때문이다.

결국 이는 리액트 사양에서의 한계이며, 따라서 불가피하게 이는 넘버링을 하며 수기로 추가하는 것으로 대체하였다.

### Transition 효과 관련

> 음... 바꿀까 말까 고민한 결과, 바꿔야겠다.

나는 최적화라는 명목하에 Transition을 `useIntersectionObserver`만으로 구현했다.
그런데... 생각해보니 유저 입장에서는 얼마나 스크롤 해야 되는지 모르는 상황이다.
이는 개인적으로 성능 향상을 위해 `scroll` event를 피했는데, UX 측면에서 오히려 덜미를 잡았다.

따라서, `scroll` event를 달아야 될 것 같다.
다만 지금은 보이는 데 문제는 없으니 기술 부채로 남겨 놓고, 이슈에 이 부분을 추가해서 적겠다.

## 🔑 참고할 만한 소스

### 동적으로 여러 개의 `RefObject` 추가
[stackoverflow](https://stackoverflow.com/questions/65350114/useref-for-element-in-loop-in-react)의 도움을 많이 받았다.

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
