### PR TITLE
[🌈 Feature] 전체 화면 전환 애니메이션을 구현한다. 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
      */
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
+    'consistent-return': 'off'
   },
   settings: {
     'import/parsers': {

--- a/atoms/common/navigator.ts
+++ b/atoms/common/navigator.ts
@@ -1,0 +1,37 @@
+import { ReactNode } from 'react';
+
+import { atom, selector } from 'recoil';
+
+const NAVIGATOR_ATOM_KEY = 'common/navigator';
+
+interface HistoryInterface {
+  key: string;
+  element: ReactNode;
+}
+
+interface NavigatorAtomInterface {
+  navigating: boolean;
+  histories: HistoryInterface[];
+  index: number;
+}
+const NavigatorAtom = atom<NavigatorAtomInterface>({
+  key: NAVIGATOR_ATOM_KEY,
+  default: {
+    navigating: false,
+    histories: [],
+    index: 0,
+  },
+});
+
+export const getLastHistory = selector({
+  key: 'common/lastHistory',
+  get: ({ get }): HistoryInterface | null => {
+    const { histories } = get(NavigatorAtom);
+    const historiesLength = histories.length;
+    if (!historiesLength) return null;
+
+    return histories[historiesLength - 1];
+  },
+});
+
+export default NavigatorAtom;

--- a/atoms/common/navigator.ts
+++ b/atoms/common/navigator.ts
@@ -1,36 +1,30 @@
 import { ReactNode } from 'react';
 
-import { atom, selector } from 'recoil';
+import { atom } from 'recoil';
 
 const NAVIGATOR_ATOM_KEY = 'common/navigator';
 
-interface HistoryInterface {
-  key: string;
-  element: ReactNode;
+export enum DirectionsEnum {
+  LEFT = 'left',
+  UP = 'up',
+  RIGHT = 'right',
+  BOTTOM = 'bottom',
 }
 
 interface NavigatorAtomInterface {
   navigating: boolean;
-  histories: HistoryInterface[];
-  index: number;
+  reversed: boolean;
+  prevPage: ReactNode | null;
+  prevKey: string;
 }
+
 const NavigatorAtom = atom<NavigatorAtomInterface>({
   key: NAVIGATOR_ATOM_KEY,
   default: {
     navigating: false,
-    histories: [],
-    index: 0,
-  },
-});
-
-export const getLastHistory = selector({
-  key: 'common/lastHistory',
-  get: ({ get }): HistoryInterface | null => {
-    const { histories } = get(NavigatorAtom);
-    const historiesLength = histories.length;
-    if (!historiesLength) return null;
-
-    return histories[historiesLength - 1];
+    reversed: false,
+    prevPage: null,
+    prevKey: '',
   },
 });
 

--- a/atoms/intro/terminal.ts
+++ b/atoms/intro/terminal.ts
@@ -14,7 +14,7 @@ export interface TerminalAtomStateInterface {
 }
 
 const IntroTarminalAtom = atom<TerminalAtomStateInterface>({
-  key: 'Intro/Terminal',
+  key: 'intro/terminal',
   default: {
     mode: null,
     loading: false,

--- a/components/Header/Base.tsx
+++ b/components/Header/Base.tsx
@@ -18,12 +18,8 @@ function Base() {
       url: '/about',
     },
     {
-      name: 'SKILLS',
-      url: '/skills',
-    },
-    {
       name: 'EXPERIENCES',
-      url: '/experiences',
+      url: '/experiences-and-projects',
     },
   ];
 

--- a/components/Header/Base.tsx
+++ b/components/Header/Base.tsx
@@ -7,7 +7,10 @@ import useWindow from '@hooks/useWindow';
 
 import { StyledBase } from './styles';
 
-function Base() {
+interface BasePropsInterface {
+  hidden?: boolean;
+}
+function Base({ hidden }: BasePropsInterface) {
   const Links = [
     {
       name: 'HOME',
@@ -27,19 +30,25 @@ function Base() {
   const { windowState } = useWindow(['location']);
 
   return (
-    <StyledBase.Header isScrollDown={isScrollDown}>
-      <StyledBase.Links>
-        {Links.map((link) => (
-          <StyledBase.LinkContainer
-            isActive={new RegExp(windowState.location?.pathname).test(link.url)}
-            key={link.name}
-          >
-            <Link href={link.url}>{link.name}</Link>
-          </StyledBase.LinkContainer>
-        ))}
-      </StyledBase.Links>
-    </StyledBase.Header>
+    <StyledBase.Container hidden={hidden}>
+      <StyledBase.Header isScrollDown={isScrollDown}>
+        <StyledBase.Links>
+          {Links.map((link) => (
+            <StyledBase.LinkContainer
+              isActive={new RegExp(windowState.location?.pathname).test(link.url)}
+              key={link.name}
+            >
+              <Link href={link.url}>{link.name}</Link>
+            </StyledBase.LinkContainer>
+          ))}
+        </StyledBase.Links>
+      </StyledBase.Header>
+    </StyledBase.Container>
   );
 }
+
+Base.defaultProps = {
+  hidden: false,
+};
 
 export default Base;

--- a/components/Header/styles.ts
+++ b/components/Header/styles.ts
@@ -75,14 +75,14 @@ export const StyledBase = {
   `,
 
   Header: styled.header<{ isScrollDown: boolean }>`
-    height: 4rem;
+    height: 3rem;
     margin: 0 auto;
 
     background: transparent;
 
     /* border-bottom: 1px solid #aaa; */
 
-    background: rgba(256, 256, 256, 0.1);
+    background: black;
     transition: all 0.3s;
     ${CommonStyle.Header}
 

--- a/components/Header/styles.ts
+++ b/components/Header/styles.ts
@@ -6,14 +6,9 @@ import CopyStyle from '@components/Text';
 
 const CommonStyle = {
   Header: css`
-    position: fixed;
-    top: 0;
-    right: 0;
-    left: 0;
-    z-index: 9999;
-
     display: flex;
     align-items: center;
+    max-width: 1440px;
   `,
   Circles: css`
     position: absolute;
@@ -71,8 +66,17 @@ export const StyledIntro = {
 };
 
 export const StyledBase = {
+  Container: styled.div`
+    position: fixed;
+    top: 0;
+    z-index: 9999;
+    width: 100vw;
+    margin: 0 auto;
+  `,
+
   Header: styled.header<{ isScrollDown: boolean }>`
     height: 4rem;
+    margin: 0 auto;
 
     background: transparent;
 

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -159,7 +159,8 @@ function Navigator({ direction, children }: NavigatorInterface) {
       setNavigatorState((state) => ({
         ...state,
         navigating: true,
-        reversed: true,
+        reversed: router.pathname !== navigatorState.prevKey,
+        prevKey: router.pathname,
       }));
     };
 
@@ -168,7 +169,9 @@ function Navigator({ direction, children }: NavigatorInterface) {
     return () => {
       window.removeEventListener('popstate', onPopState);
     };
-  }, [setNavigatorState]);
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [setNavigatorState, navigatorState.prevKey]);
 
   /**
    * NOTE: <스크롤 이벤트 관련>

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -1,0 +1,112 @@
+import React, { AnimationEvent, ReactElement, useEffect } from 'react';
+
+import { useRouter } from 'next/router';
+
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import styled from '@emotion/styled';
+
+import NavigatorAtom, { getLastHistory } from '@atoms/common/navigator';
+
+const Page = styled.div`
+  position: absolute;
+  width: 100%;
+`;
+
+const Styled = {
+  Navigator: styled.div`
+    position: relative;
+    height: 100vh;
+    perspective: 100vw;
+  `,
+  Prev: styled(Page)<{ navigating: boolean }>`
+    position: relative;
+    z-index: -1000;
+    transform-origin: center;
+
+    animation: navigate-page-prev 1s forwards;
+
+    @keyframes navigate-page-prev {
+      to {
+        opacity: 0;
+        transform: translateX(-10%) translateZ(-200px);
+        transform-style: preserve-3d;
+      }
+    }
+  `,
+  Now: styled(Page)<{ navigating: boolean }>`
+    z-index: 1000;
+    transform: translateX(100%);
+
+    animation: navigate-page-now 1s forwards;
+    @keyframes navigate-page-now {
+      to {
+        transform: translateX(0%);
+      }
+    }
+  `,
+};
+
+function Navigator({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [navigatorState, setNavigatorState] = useRecoilState(NavigatorAtom);
+
+  const lastHistory = useRecoilValue(getLastHistory);
+
+  useEffect(() => {
+    setNavigatorState((state) => ({
+      ...state,
+      navigating: true,
+    }));
+
+    return () => {
+      if (lastHistory?.key !== router.pathname)
+        setNavigatorState((state) => ({
+          ...state,
+          navigating: false,
+          index: state.index + 1,
+          histories: [
+            ...state.histories,
+            { key: `${Date.now()}`, element: React.cloneElement(children as ReactElement) },
+          ],
+        }));
+    };
+
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [router.pathname]);
+
+  const onNavigatePrevPage = (e: AnimationEvent) => {
+    if (!e.animationName.includes('navigate-page')) return;
+
+    setNavigatorState((state) => ({
+      ...state,
+      navigating: false,
+    }));
+  };
+
+  return (
+    <Styled.Navigator id="navigator">
+      <Styled.Now
+        key={router.pathname}
+        id="now"
+        onAnimationEnd={onNavigatePrevPage}
+        navigating={navigatorState.navigating}
+      >
+        {children}
+      </Styled.Now>
+
+      {!!navigatorState.navigating && !!navigatorState.histories.length && lastHistory !== null && (
+        <Styled.Prev
+          id="prev"
+          key={lastHistory.key}
+          onAnimationEnd={onNavigatePrevPage}
+          navigating={navigatorState.navigating}
+        >
+          {navigatorState.histories[navigatorState.histories.length - 1].element}
+        </Styled.Prev>
+      )}
+    </Styled.Navigator>
+  );
+}
+
+export default Navigator;

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -170,14 +170,24 @@ function Navigator({ direction, children }: NavigatorInterface) {
     };
   }, [setNavigatorState]);
 
+  /**
+   * NOTE: <스크롤 이벤트 관련>
+   * WARNING:
+   * 현재 이 부분에 대해서는 주석으로 남겨놓는 것이 맞을 것 같다.
+   * 현재 scroll은 window에 걸린 것이 아닌, Now Page 컴포넌트에 걸려있는 상태이다.
+   * 이유는, 오히려 window에 걸어주었다가는 제대로 동작하지 않아 더 헷갈릴 확률이 높아서다.
+   * 따라서 이를 앞으로 손쉽게 관리하기 위해 오버라이딩을 해주었다.
+   */
   useEffect(() => {
     if (pageRef.current === null) return;
 
-    pageRef.current.addEventListener('scroll', () => {
-      const customEvent = new CustomEvent('page-scroll', { detail: { name: 'hi' } });
+    const onScroll = () => {
+      const customEvent = new CustomEvent('scroll', { detail: { name: 'hi' } });
       window.dispatchEvent(customEvent);
-    });
-  }, [pageRef]);
+    };
+
+    pageRef.current.addEventListener('scroll', onScroll, { passive: true });
+  }, [pageRef, router.pathname]);
 
   useEffect(() => {
     setNavigatorState((state) => ({

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -19,24 +19,25 @@ const Styled = {
     display: flex;
     height: 100vh;
     perspective: 100vw;
+    overflow: hidden;
   `,
   Prev: styled(Page)`
     position: relative;
     z-index: -1000;
     transform-origin: center;
 
-    /* animation: ${({ direction, navigating }) =>
+    animation: ${({ direction, navigating }) =>
       navigating
         ? ` navigate-page-prev-${direction} 1s forwards;
       `
-        : ``}; */
+        : ``};
 
     @keyframes navigate-page-prev-left {
       from {
         transform: translateX(0%);
       }
       to {
-        transform: translateX(-10%);
+        transform: translateX(-100%);
       }
     }
     @keyframes navigate-page-prev-right {
@@ -44,7 +45,7 @@ const Styled = {
         transform: translateX(0%);
       }
       to {
-        transform: translateX(10%);
+        transform: translateX(100%);
       }
     }
     @keyframes navigate-page-up {
@@ -52,7 +53,7 @@ const Styled = {
         transform: translateY(0%);
       }
       to {
-        transform: translateY(-10%);
+        transform: translateY(-100%);
       }
     }
 
@@ -61,7 +62,7 @@ const Styled = {
         transform: translateY(0%);
       }
       to {
-        transform: translateY(10%);
+        transform: translateY(100%);
       }
     }
   `,
@@ -189,11 +190,13 @@ function Navigator({ direction, children }: NavigatorInterface) {
 
   return (
     <Styled.Navigator id="navigator">
-      {navigatorState.prevPage && (
-        <Styled.Prev direction={finalDirection} navigating={navigatorState.navigating}>
-          {navigatorState.prevPage}
-        </Styled.Prev>
-      )}
+      {navigatorState.prevKey !== router.pathname &&
+        navigatorState.navigating &&
+        navigatorState.prevPage && (
+          <Styled.Prev direction={finalDirection} navigating={navigatorState.navigating}>
+            {navigatorState.prevPage}
+          </Styled.Prev>
+        )}
 
       <Styled.Now
         key={router.pathname}

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -1,4 +1,11 @@
-import React, { AnimationEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import React, {
+  AnimationEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useRouter } from 'next/router';
 
@@ -120,6 +127,8 @@ interface NavigatorInterface {
 function Navigator({ direction, children }: NavigatorInterface) {
   const router = useRouter();
 
+  const pageRef = useRef<HTMLDivElement>(null);
+
   const [navigatorState, setNavigatorState] = useRecoilState(NavigatorAtom);
   const [isFinished, setIsFinished] = useState(false);
 
@@ -162,6 +171,15 @@ function Navigator({ direction, children }: NavigatorInterface) {
   }, [setNavigatorState]);
 
   useEffect(() => {
+    if (pageRef.current === null) return;
+
+    pageRef.current.addEventListener('scroll', () => {
+      const customEvent = new CustomEvent('page-scroll', { detail: { name: 'hi' } });
+      window.dispatchEvent(customEvent);
+    });
+  }, [pageRef]);
+
+  useEffect(() => {
     setNavigatorState((state) => ({
       ...state,
       navigating: true,
@@ -202,6 +220,7 @@ function Navigator({ direction, children }: NavigatorInterface) {
         )}
 
       <Styled.Now
+        ref={pageRef}
         key={router.pathname}
         id="now"
         isFirstRender={!navigatorState.prevKey || navigatorState.prevKey === router.pathname}

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -11,6 +11,8 @@ import NavigatorAtom, { DirectionsEnum } from '@atoms/common/navigator';
 const Page = styled.div<{ direction: DirectionsEnum; navigating: boolean }>`
   position: absolute;
   width: 100%;
+  height: 100vh;
+  overflow-y: scroll;
 `;
 
 const Styled = {
@@ -117,6 +119,7 @@ interface NavigatorInterface {
 
 function Navigator({ direction, children }: NavigatorInterface) {
   const router = useRouter();
+
   const [navigatorState, setNavigatorState] = useRecoilState(NavigatorAtom);
   const [isFinished, setIsFinished] = useState(false);
 

--- a/components/Navigator/Navigator.tsx
+++ b/components/Navigator/Navigator.tsx
@@ -1,14 +1,14 @@
-import React, { AnimationEvent, ReactElement, useEffect } from 'react';
+import React, { AnimationEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 
 import { useRouter } from 'next/router';
 
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import styled from '@emotion/styled';
 
-import NavigatorAtom, { getLastHistory } from '@atoms/common/navigator';
+import NavigatorAtom, { DirectionsEnum } from '@atoms/common/navigator';
 
-const Page = styled.div`
+const Page = styled.div<{ direction: DirectionsEnum; navigating: boolean }>`
   position: absolute;
   width: 100%;
 `;
@@ -16,42 +16,146 @@ const Page = styled.div`
 const Styled = {
   Navigator: styled.div`
     position: relative;
+    display: flex;
     height: 100vh;
     perspective: 100vw;
   `,
-  Prev: styled(Page)<{ navigating: boolean }>`
+  Prev: styled(Page)`
     position: relative;
     z-index: -1000;
     transform-origin: center;
 
-    animation: navigate-page-prev 1s forwards;
+    /* animation: ${({ direction, navigating }) =>
+      navigating
+        ? ` navigate-page-prev-${direction} 1s forwards;
+      `
+        : ``}; */
 
-    @keyframes navigate-page-prev {
+    @keyframes navigate-page-prev-left {
+      from {
+        transform: translateX(0%);
+      }
       to {
-        opacity: 0;
-        transform: translateX(-10%) translateZ(-200px);
-        transform-style: preserve-3d;
+        transform: translateX(-10%);
+      }
+    }
+    @keyframes navigate-page-prev-right {
+      from {
+        transform: translateX(0%);
+      }
+      to {
+        transform: translateX(10%);
+      }
+    }
+    @keyframes navigate-page-up {
+      from {
+        transform: translateY(0%);
+      }
+      to {
+        transform: translateY(-10%);
+      }
+    }
+
+    @keyframes navigate-page-prev-bottom {
+      from {
+        transform: translateY(0%);
+      }
+      to {
+        transform: translateY(10%);
       }
     }
   `,
-  Now: styled(Page)<{ navigating: boolean }>`
-    z-index: 1000;
-    transform: translateX(100%);
 
-    animation: navigate-page-now 1s forwards;
-    @keyframes navigate-page-now {
+  Now: styled(Page)<{ isFirstRender: boolean }>`
+    z-index: 1000;
+    animation: ${({ isFirstRender, direction, navigating }) =>
+      !isFirstRender && navigating
+        ? ` navigate-page-now-${direction} 1s forwards;
+      `
+        : ``};
+    @keyframes navigate-page-now-left {
+      from {
+        transform: translateX(100%);
+      }
       to {
         transform: translateX(0%);
+      }
+    }
+    @keyframes navigate-page-now-right {
+      from {
+        transform: translateX(-100%);
+      }
+      to {
+        transform: translateX(0%);
+      }
+    }
+
+    @keyframes navigate-page-up {
+      from {
+        transform: translateY(100%);
+      }
+      to {
+        transform: translateY(0%);
+      }
+    }
+    @keyframes navigate-page-bottom {
+      from {
+        transform: translateY(-100%);
+      }
+      to {
+        transform: translateY(0%);
       }
     }
   `,
 };
 
-function Navigator({ children }: { children: React.ReactNode }) {
+interface NavigatorInterface {
+  direction: DirectionsEnum;
+  children: React.ReactNode;
+}
+
+function Navigator({ direction, children }: NavigatorInterface) {
   const router = useRouter();
   const [navigatorState, setNavigatorState] = useRecoilState(NavigatorAtom);
+  const [isFinished, setIsFinished] = useState(false);
 
-  const lastHistory = useRecoilValue(getLastHistory);
+  const finalDirection = useMemo(() => {
+    const reversed = {
+      left: DirectionsEnum.RIGHT,
+      right: DirectionsEnum.LEFT,
+      up: DirectionsEnum.BOTTOM,
+      bottom: DirectionsEnum.UP,
+    };
+
+    if (isFinished) {
+      if (navigatorState.reversed) return reversed[direction];
+    }
+
+    return navigatorState.reversed ? reversed[direction] : direction;
+  }, [isFinished, navigatorState, direction]);
+
+  /* NOTE:
+   * 1. popstate -> navigating true, reversed true
+   * 2. unmount prev page -> navigating false;
+   * 3. mount now page -> navigating true;
+   * 4. animated
+   * 5. animationEnd -> isFinished true, reversed false
+   */
+  useLayoutEffect(() => {
+    const onPopState = () => {
+      setNavigatorState((state) => ({
+        ...state,
+        navigating: true,
+        reversed: true,
+      }));
+    };
+
+    window.addEventListener('popstate', onPopState);
+
+    return () => {
+      window.removeEventListener('popstate', onPopState);
+    };
+  }, [setNavigatorState]);
 
   useEffect(() => {
     setNavigatorState((state) => ({
@@ -60,51 +164,47 @@ function Navigator({ children }: { children: React.ReactNode }) {
     }));
 
     return () => {
-      if (lastHistory?.key !== router.pathname)
-        setNavigatorState((state) => ({
-          ...state,
-          navigating: false,
-          index: state.index + 1,
-          histories: [
-            ...state.histories,
-            { key: `${Date.now()}`, element: React.cloneElement(children as ReactElement) },
-          ],
-        }));
+      setNavigatorState((state) => ({
+        ...state,
+        navigating: false,
+        prevPage: React.cloneElement(children as React.ReactElement),
+        prevKey: router.pathname,
+      }));
     };
-
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [router.pathname]);
+  }, [setNavigatorState, router.pathname]);
 
-  const onNavigatePrevPage = (e: AnimationEvent) => {
-    if (!e.animationName.includes('navigate-page')) return;
+  const finishNavigate = (e: AnimationEvent) => {
+    if (e.animationName.startsWith('navigate-page')) {
+      setIsFinished(() => true);
 
-    setNavigatorState((state) => ({
-      ...state,
-      navigating: false,
-    }));
+      setNavigatorState((state) => ({
+        ...state,
+        navigating: false,
+        reversed: false,
+        prevPage: React.cloneElement(children as React.ReactElement),
+      }));
+    }
   };
 
   return (
     <Styled.Navigator id="navigator">
+      {navigatorState.prevPage && (
+        <Styled.Prev direction={finalDirection} navigating={navigatorState.navigating}>
+          {navigatorState.prevPage}
+        </Styled.Prev>
+      )}
+
       <Styled.Now
         key={router.pathname}
         id="now"
-        onAnimationEnd={onNavigatePrevPage}
+        isFirstRender={!navigatorState.prevKey || navigatorState.prevKey === router.pathname}
+        direction={finalDirection}
         navigating={navigatorState.navigating}
+        onAnimationEnd={finishNavigate}
       >
         {children}
       </Styled.Now>
-
-      {!!navigatorState.navigating && !!navigatorState.histories.length && lastHistory !== null && (
-        <Styled.Prev
-          id="prev"
-          key={lastHistory.key}
-          onAnimationEnd={onNavigatePrevPage}
-          navigating={navigatorState.navigating}
-        >
-          {navigatorState.histories[navigatorState.histories.length - 1].element}
-        </Styled.Prev>
-      )}
     </Styled.Navigator>
   );
 }

--- a/components/Navigator/types.ts
+++ b/components/Navigator/types.ts
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+
+const enum NavigatorDirections {
+  LEFT = 'LEFT',
+  TOP = 'TOP',
+  BOTTOM = 'BOTTOM',
+  RIGHT = 'RIGHT',
+}
+export interface StyledNavigatorProps {
+  navigate: boolean;
+  direction: NavigatorDirections;
+  delay: number;
+  height: string;
+}
+
+export interface NavigatorProps {
+  children: ReactNode;
+  delay?: number;
+  height?: string;
+  directions: {
+    [index: string]: NavigatorDirections;
+  };
+}
+
+export interface RoutePageProps {
+  height: string;
+}
+
+export default NavigatorDirections;

--- a/components/Navigator/types.ts
+++ b/components/Navigator/types.ts
@@ -1,29 +1,8 @@
-import { ReactNode } from 'react';
-
 const enum NavigatorDirections {
   LEFT = 'LEFT',
   TOP = 'TOP',
   BOTTOM = 'BOTTOM',
   RIGHT = 'RIGHT',
-}
-export interface StyledNavigatorProps {
-  navigate: boolean;
-  direction: NavigatorDirections;
-  delay: number;
-  height: string;
-}
-
-export interface NavigatorProps {
-  children: ReactNode;
-  delay?: number;
-  height?: string;
-  directions: {
-    [index: string]: NavigatorDirections;
-  };
-}
-
-export interface RoutePageProps {
-  height: string;
 }
 
 export default NavigatorDirections;

--- a/components/Terminal/Body.tsx
+++ b/components/Terminal/Body.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
+import { useRouter } from 'next/router';
+
 import { useRecoilState } from 'recoil';
 
 import { IntroTarminalAtom } from '@atoms';
@@ -63,6 +65,7 @@ function TerminalBodyLogs({ isActive, initDelay }: TerminalBodyLogsInterface) {
   ]);
 
   const [logClassNames, setLogClassNames] = useState(new Array(logs.length).fill(''));
+  const router = useRouter();
 
   /**
    * @description
@@ -87,6 +90,12 @@ function TerminalBodyLogs({ isActive, initDelay }: TerminalBodyLogsInterface) {
               i === idx ? [className, 'log--visible'].join(' ') : className
             )
           );
+
+          setTimeout(() => {
+            if (idx === logDelays.length - 1) {
+              router.push('/about');
+            }
+          }, 300);
         }, delay * 1000);
       });
     }

--- a/components/Terminal/Body.tsx
+++ b/components/Terminal/Body.tsx
@@ -99,8 +99,7 @@ function TerminalBodyLogs({ isActive, initDelay }: TerminalBodyLogsInterface) {
         }, delay * 1000);
       });
     }
-    //
-  }, [isActive, logDelays]);
+  }, [isActive, logDelays, router]);
 
   return (
     <StyledBody.Logs isActive={isActive}>

--- a/components/layouts/BaseLayout.tsx
+++ b/components/layouts/BaseLayout.tsx
@@ -3,13 +3,15 @@ import React, { ReactElement } from 'react';
 import { BaseHeader } from '@components/Header';
 import Navigator from '@components/Navigator/Navigator';
 
+import { DirectionsEnum } from '@atoms/common/navigator';
+
 import { LayoutInterface } from './types';
 
 function BaseLayout({ children }: LayoutInterface) {
   return (
     <>
       <BaseHeader />
-      <Navigator>
+      <Navigator direction={DirectionsEnum.LEFT}>
         <main>{children}</main>
       </Navigator>
     </>

--- a/components/layouts/BaseLayout.tsx
+++ b/components/layouts/BaseLayout.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import { BaseHeader } from '@components/Header';
+import Navigator from '@components/Navigator/Navigator';
 
 import { LayoutInterface } from './types';
 
@@ -8,7 +9,9 @@ function BaseLayout({ children }: LayoutInterface) {
   return (
     <>
       <BaseHeader />
-      <main>{children}</main>
+      <Navigator>
+        <main>{children}</main>
+      </Navigator>
     </>
   );
 }

--- a/components/layouts/BaseLayout.tsx
+++ b/components/layouts/BaseLayout.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from 'react';
 
+import { useRouter } from 'next/router';
+
 import { BaseHeader } from '@components/Header';
 import Navigator from '@components/Navigator/Navigator';
 
@@ -8,9 +10,11 @@ import { DirectionsEnum } from '@atoms/common/navigator';
 import { LayoutInterface } from './types';
 
 function BaseLayout({ children }: LayoutInterface) {
+  const router = useRouter();
+
   return (
     <>
-      <BaseHeader />
+      <BaseHeader hidden={router.pathname === '/'} />
       <Navigator direction={DirectionsEnum.LEFT}>
         <main>{children}</main>
       </Navigator>

--- a/components/layouts/IntroLayout.tsx
+++ b/components/layouts/IntroLayout.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 
 import { IntroHeader } from '@components/Header';
+import Navigator from '@components/Navigator/Navigator';
 
 import { LayoutInterface } from './types';
 
@@ -8,7 +9,9 @@ function IntroLayout({ children }: LayoutInterface) {
   return (
     <>
       <IntroHeader />
-      <main>{children}</main>
+      <Navigator>
+        <main>{children}</main>
+      </Navigator>
     </>
   );
 }

--- a/components/layouts/IntroLayout.tsx
+++ b/components/layouts/IntroLayout.tsx
@@ -3,13 +3,15 @@ import React, { ReactElement } from 'react';
 import { IntroHeader } from '@components/Header';
 import Navigator from '@components/Navigator/Navigator';
 
+import { DirectionsEnum } from '@atoms/common/navigator';
+
 import { LayoutInterface } from './types';
 
 function IntroLayout({ children }: LayoutInterface) {
   return (
     <>
       <IntroHeader />
-      <Navigator>
+      <Navigator direction={DirectionsEnum.LEFT}>
         <main>{children}</main>
       </Navigator>
     </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import type { AppProps } from 'next/app';
 
 import { RecoilRoot } from 'recoil';
 
+// import Navigator from '@components/Navigator/Navigator';
 import { globalStyle, globalTheme } from '@styles/index';
 
 /**
@@ -25,7 +26,6 @@ export type AppPropsWithLayout = AppProps & {
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   // NOTE: 이는 Next.js에서 기본적으로 주어진 코드이므로 그냥 사용하려 한다.
   const getLayout = Component.getLayout ?? ((page) => page);
-
   return (
     <ThemeProvider theme={globalTheme}>
       <Global styles={globalStyle} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,8 +30,8 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     <ThemeProvider theme={globalTheme}>
       <Global styles={globalStyle} />
       <RecoilRoot>
-        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-        {getLayout(<Component {...pageProps} />)}
+        {/* eslint-disable react/jsx-props-no-spreading */}
+        {getLayout(<Component key={Component.prototype.constructor.name} {...pageProps} />)}
       </RecoilRoot>
     </ThemeProvider>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,6 @@ import type { AppProps } from 'next/app';
 
 import { RecoilRoot } from 'recoil';
 
-// import Navigator from '@components/Navigator/Navigator';
 import { globalStyle, globalTheme } from '@styles/index';
 
 /**

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -10,6 +10,7 @@ import { GradientType } from '@components/Metaball/types';
 import { ScrollMouse } from '@components/Mouse';
 import { CollapsedText } from '@components/Text';
 import Gummy from '@components/Text/Gummy';
+import { getBaseLayout } from '@components/layouts';
 
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import useMetaball from '@hooks/useMetaball';
@@ -974,5 +975,5 @@ function AboutPage() {
     </Styled.Page>
   );
 }
-
+AboutPage.getLayout = getBaseLayout;
 export default AboutPage;

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -484,6 +484,7 @@ function AboutPage() {
   ];
 
   const canvasRef = useRef(null);
+
   useMetaball({
     canvasRef,
     gradient: initialGradientColors,
@@ -655,18 +656,29 @@ function AboutPage() {
     rootMargin: '-200px',
   });
 
+  const pageRef = useRef<HTMLElement>(null);
+
   useEffect(() => {
-    const { clientHeight } = document.body;
+    if (pageRef.current === null) return;
+
+    const { height: clientHeight, y } = pageRef.current.getBoundingClientRect();
+
     if (headerState.y === 0) {
       setHeaderState((state) => ({
         ...state,
-        y: window.scrollY,
+        y: y * -1,
       }));
-      return undefined;
+
+      return;
     }
 
     const onScroll = throttle(() => {
-      const { scrollY, innerHeight } = window;
+      if (pageRef.current === null) return;
+
+      const { innerHeight } = window;
+
+      const scrollY = pageRef.current.getBoundingClientRect().y * -1;
+
       if (clientHeight + innerHeight <= scrollY) return;
 
       const diffScroll = scrollY - headerState.y;
@@ -680,6 +692,7 @@ function AboutPage() {
           origin: 'top left',
           opacity: Math.max(diffRate, 0.3),
         }));
+
         return;
       }
 
@@ -691,16 +704,18 @@ function AboutPage() {
         origin: 'top left',
         opacity: 0.3,
       }));
+
+      return undefined;
     }, 20);
 
     if (headerState.isActive) {
-      window.addEventListener('scroll', onScroll);
+      window.addEventListener('page-scroll', onScroll);
     } else {
-      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('page-scroll', onScroll);
     }
 
     return () => {
-      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('page-scroll', onScroll);
     };
   }, [headerState.isActive, headerState.y]);
 
@@ -860,7 +875,7 @@ function AboutPage() {
   ];
 
   return (
-    <Styled.Page>
+    <Styled.Page ref={pageRef}>
       <Styled.Introduction>
         <ForwardedCanvas width={minWidth} height={minHeight} ref={canvasRef} />
         <Styled.IntroductionMainCopy>

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -709,13 +709,13 @@ function AboutPage() {
     }, 20);
 
     if (headerState.isActive) {
-      window.addEventListener('page-scroll', onScroll);
+      window.addEventListener('scroll', onScroll);
     } else {
-      window.removeEventListener('page-scroll', onScroll);
+      window.removeEventListener('scroll', onScroll);
     }
 
     return () => {
-      window.removeEventListener('page-scroll', onScroll);
+      window.removeEventListener('scroll', onScroll);
     };
   }, [headerState.isActive, headerState.y]);
 

--- a/pages/experiences-and-projects/index.tsx
+++ b/pages/experiences-and-projects/index.tsx
@@ -9,6 +9,7 @@ import { Browser, ProjectInterface } from '@components/Browser';
 import LinksImage, { ImageSizeOption } from '@components/Links/LinksImage';
 import { CollapsedText } from '@components/Text';
 import Gummy from '@components/Text/Gummy';
+import { getBaseLayout } from '@components/layouts';
 
 import useIntersectionObserver from '@hooks/useIntersectionObserver';
 
@@ -1146,7 +1147,7 @@ function ExperiencesAndProjectsPage() {
                 shouldShowHistories={shouldShowHistories[idx]}
               >
                 {nowExperience.images.map((obj) => (
-                  <StyledExperience.ImageContainer>
+                  <StyledExperience.ImageContainer key={obj.src}>
                     <LinksImage
                       image={{ src: obj.src, alt: obj.alt }}
                       imageOptions={{
@@ -1247,4 +1248,5 @@ function ExperiencesAndProjectsPage() {
   );
 }
 
+ExperiencesAndProjectsPage.getLayout = getBaseLayout;
 export default ExperiencesAndProjectsPage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 
 import { ScrollMouse } from '@components/Mouse';
 import { Terminal } from '@components/Terminal';
-import { getIntroLayout } from '@components/layouts';
+import { getBaseLayout } from '@components/layouts';
 
 import { useLocalStorage } from '@hooks/useLocalStorage';
 
@@ -129,5 +129,5 @@ function HomePage() {
   );
 }
 
-HomePage.getLayout = getIntroLayout;
+HomePage.getLayout = getBaseLayout;
 export default HomePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,7 @@ import styled from '@emotion/styled';
 
 import { ScrollMouse } from '@components/Mouse';
 import { Terminal } from '@components/Terminal';
-import { getBaseLayout } from '@components/layouts';
+import { getIntroLayout } from '@components/layouts';
 
 import { useLocalStorage } from '@hooks/useLocalStorage';
 
@@ -129,5 +129,5 @@ function HomePage() {
   );
 }
 
-HomePage.getLayout = getBaseLayout;
+HomePage.getLayout = getIntroLayout;
 export default HomePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,6 +36,7 @@ const Styled = {
     justify-content: center;
 
     width: 100%;
+    height: calc(100vh + 4px);
 
     &::before,
     &::after {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,7 @@ import styled from '@emotion/styled';
 
 import { ScrollMouse } from '@components/Mouse';
 import { Terminal } from '@components/Terminal';
+import { getBaseLayout } from '@components/layouts';
 
 import { useLocalStorage } from '@hooks/useLocalStorage';
 
@@ -128,4 +129,5 @@ function HomePage() {
   );
 }
 
+HomePage.getLayout = getBaseLayout;
 export default HomePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,6 @@ const Styled = {
     justify-content: center;
 
     width: 100%;
-    height: calc(100vh + 4px);
 
     &::before,
     &::after {

--- a/styles/globalStyle.ts
+++ b/styles/globalStyle.ts
@@ -12,7 +12,9 @@ const globalStyle = css`
 
   #__next,
   body {
+    width: 100%;
     min-height: 100vh;
+    overflow-y: hidden;
   }
 
   a {

--- a/styles/globalStyle.ts
+++ b/styles/globalStyle.ts
@@ -12,9 +12,7 @@ const globalStyle = css`
 
   #__next,
   body {
-    width: 100%;
     min-height: 100vh;
-    overflow-y: hidden;
   }
 
   a {


### PR DESCRIPTION
## 🚀 설명

https://user-images.githubusercontent.com/78713176/201381250-ed1e244f-9343-4c9d-9b69-21f90debd349.mov


전반적인 화면 전환을 왼쪽 -> 오른쪽으로 이동하는 네비게이터를 구현하여 완료했다.

## 🔗 관련 이슈와 링크

> `github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉

## 🔥 논의해 볼 사항

### 와이어프레임의 내용 변경

화면 전환은 정말 많은 타협이 이루어진 파트였다.
원래는 검은 화면을 그리고 -> 새로운 페이지가 자연스럽게 나타나는 방식을 생각했다.

그러나 생각해보자. 검은 화면을 빠르게 지우면 굉장히 UX가 떨어진다. 따라서 최소한 2초는 넉넉히 잡고 검은 화면을 뿌려야 한다.
그리고 나타나는 것 역시 뭔가 동적으로 서서히 나와야 하는데, 이 역시 1~2초는 족히 걸린다.
따라서 화면 전환이 도합 4초가 걸리는 데, 이것이 과연 UX적으로 좋은지가 의문이었다.

그렇기에 한 3시간 고민한 결과, 맥북의 일관성에 맞는 방법을 찾아냈다.
맥북에서 왼쪽 - 오른쪽으로 이동할 때 화면 자체가 같이 이동한다.
이를 여기서 구현했다. 

### 구현 방법

원리는 key를 주어 언마운트가 되어도 transition이 걸릴 수 있게 해주고, 방향을 동적으로 관리해주는 것이다.
이때, 전역 상태 관리 라이브러리를 사용했다. 이유는 렌더링과 별개로 State를 관리하는 것이 안정성에 있어 더 좋을 것 같아서다.
사실 `react-transition-group`이라는 라이브러리도 있다고 해서 이를 써주면 되는 듯 하지만, 이전에 이런 방식의 컴포넌트를 구현해본 적 있어서 다시 한 번 했다.

### 뷰포트 기준 변경

이 역시 많은 고민 끝에 바꾼 결정이다. 이거도 한 3시간 고민한 듯...
고민은 다음과 같았다.

> 1. 만약 y가 2000px을 넘어갔다 
> 2. 스크롤이 바뀐 상태에서 스크롤 없는 페이지로 이동 
> 3. 이동하는 내내 검은 화면이 뜨다가 갑자기 화면이 나오는 현상

이런 문제를 어떻게 해결할 수 있을지 고민하다, 아예 스크롤을 바꾸는 방식을 택했다.
전체 스크롤을 overflow로 하고, 페이지만 overflow-y를 scroll로 했다.

이후 커스텀 이벤트를 적용하여, 기존의 scroll event를 오버라이딩했다.

결과적으로, 기존의 동작은 유지하되, 깔쌈한 전환 애니메이션을 구현했다고 생각한다!


## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
