### PR TITLE
:bug: 경험 페이지에서 다시 소개 페이지로 이동 후 아이콘의 잘못된 애니메이션을 수정한다.

### DIFF
--- a/pages/experiences-and-projects/index.tsx
+++ b/pages/experiences-and-projects/index.tsx
@@ -100,10 +100,10 @@ const StyledExperience = {
     ${({ reversed }) =>
       reversed &&
       css`
-        animation: element-jump 0.3s forwards;
+        animation: reverse-text 0.3s forwards;
         animation-delay: 0.25s;
 
-        @keyframes element-jump {
+        @keyframes reverse-text {
           to {
             transform: rotate(180deg) scale(1.1);
             transform-origin: 50% 60%;


### PR DESCRIPTION
## 🚀 설명

- 원인: element-jump라는 키프레임이 CSS에서 공유되고 있음을 확인했다.
- 해결: 애니메이션의 이름을 겹치지 않게 수정했다.

실제로 빌드 후 시도해보니 잘 됐다!

### 시연

https://user-images.githubusercontent.com/78713176/201629325-6357aea6-c377-4511-9a9d-22568efed0b8.mov


## 🔗 관련 이슈와 링크

closes #61

## 🔥 논의해 볼 사항

> 해결한 건 어렵지 않다.
> 그런데 '왜' keyframe이 공유되었는지를 설명할 수 있어야 한다.

따라서 이를 꼭 문서화하고 이슈 트래킹하여 기록으로 남기도록 한다.

## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
