### PR TITLE
fix(css-style): 브라우저 컴포넌트에서 초기화 시 글자 위치가 잘못 나오는 현상을 해결한다

### DIFF
--- a/components/Browser/Main.tsx
+++ b/components/Browser/Main.tsx
@@ -88,7 +88,7 @@ function Browser({ project, projectIndex }: BrowserProps) {
           ))}
 
         {projectIndex < 0 && (
-          <>
+          <Styled.EmptyContainer>
             <Styled.InitText>왼쪽의 프로젝트를</Styled.InitText>
             <Styled.InitText>
               <strong>
@@ -96,7 +96,7 @@ function Browser({ project, projectIndex }: BrowserProps) {
               </strong>
               해주세요!
             </Styled.InitText>
-          </>
+          </Styled.EmptyContainer>
         )}
       </Styled.Body>
     </Styled.Container>

--- a/components/Browser/styles.ts
+++ b/components/Browser/styles.ts
@@ -225,4 +225,12 @@ export const Styled = {
       color: ${({ theme }) => theme.colors.primary.light};
     }
   `,
+  EmptyContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  `,
 };

--- a/package.json
+++ b/package.json
@@ -65,9 +65,12 @@
   },
   "packageManager": "yarn@3.3.0",
   "lint-staged": {
+    "*.{js,json,md,html}": [
+      "prettier --write **/*.{js,json,md,html} --ignore-unknown --no-error-on-unmatched-pattern"
+    ],
     "*.{tsx,ts}": [
-      "prettier --write --no-error-on-unmatched-pattern",
-      "eslint --fix --ext (.ts|.tsx) --no-error-on-unmatched-pattern",
+      "prettier --write **/*.{tsx,ts} --ignore-unknown --no-error-on-unmatched-pattern",
+      "eslint --fix",
       "stylelint --fix",
       "git add"
     ]


### PR DESCRIPTION
## 🚀 설명

스타일을 지정하여 문제를 해결했다.
매우 간단한 문제라 설명을 생략한다.

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/78713176/205333390-6ebce296-eba0-4af8-820f-9bd75e078d05.png">


## 🔗 관련 이슈와 링크

closes #96 

## 🔥 논의해 볼 사항

> PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!
> 예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭

## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
