### PR TITLE
[💫 CI/CD] 캐시 컨트롤을 위해 워크플로우를 수정한다

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,7 +4,7 @@
 name: Depoly Portfolio Application to AWS S3 Bucket (Static Web)
 
 on:
-  push:
+  pull_request:
     # NOTE: `main` branch has rule of managing deploy portfolio app in my repo!
     branches: ['main']
 
@@ -46,7 +46,7 @@ jobs:
       - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!*\.*]" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!.]" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!.]" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*[!.]*" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,7 +52,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
-        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
+        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
              --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" \
              --metadata-directive --recursive REPLACE --cache-control max-age=300
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,7 +52,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
-        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "**/*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive --recursive REPLACE --cache-control max-age=300
+        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "**/*.(jpg|png|svg|ico|mp4|webp)*" --metadata-directive --recursive REPLACE --cache-control max-age=300
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!\.]" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,7 +46,7 @@ jobs:
       - run: aws s3 sync ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,7 +46,7 @@ jobs:
       - run: aws s3 sync ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: remove .html files extension
-        run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
+        run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
         run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!*\.*]" --content-type "text/html" --acl public-read --delete 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
-        run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
+        run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
              --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" \
-             --metadata-directive --recursive REPLACE --cache-control max-age=300
+             --metadata-directive REPLACE --cache-control max-age=600
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,10 +49,10 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.(jpg|png|svg|ico|mp4|webp)" --content-type "text/html" --acl public-read --delete
+        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --acl public-read --cache-control max-age=0,must-revalidate,public --content-type \"text/html; charset=utf-8\"
 
       - name: Copy Other Assets
-        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300
+        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300,must-revalidate
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,7 +4,7 @@
 name: Depoly Portfolio Application to AWS S3 Bucket (Static Web)
 
 on:
-  pull_request:
+  push:
     # NOTE: `main` branch has rule of managing deploy portfolio app in my repo!
     branches: ['main']
 
@@ -43,16 +43,16 @@ jobs:
       - name: delete all files
         run: aws s3 rm ${{ secrets.AWS_S3_BUCKET_NAME }}/ --recursive
 
-      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/ --recursive
+      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
+
+      - name: Set HTML Content-Type and Copy them
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
-      - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --acl public-read --cache-control max-age=0,must-revalidate,public --content-type \"text/html; charset=utf-8\"
-
       - name: Copy Other Assets
-        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300,must-revalidate
+        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "**/*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive --recursive REPLACE --cache-control max-age=300
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,13 +46,13 @@ jobs:
       - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
-        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
+        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
              --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" \
              --metadata-directive --recursive REPLACE --cache-control max-age=300
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -48,9 +48,11 @@ jobs:
       - name: Set HTML Content-Type and Copy them
         run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
+      # - name: remove .html files extension
+      #  run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
+      
       - name: remove .html files extension
-        run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
-
+        run: aws mv ${{ secrets.AWS_S3_BUCKET_NAME }}/*.html ${{ secrets.AWS_S3_BUCKET_NAME }}/*%%.html
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,7 +43,7 @@ jobs:
       - name: delete all files
         run: aws s3 rm ${{ secrets.AWS_S3_BUCKET_NAME }}/ --recursive
 
-      - run: aws s3 sync ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
+      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!*.*]" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!*\.*]" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,9 +52,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
-        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
-             --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" \
-             --metadata-directive REPLACE --cache-control max-age=600
+        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*[!.]*" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!.*]" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -45,14 +45,12 @@ jobs:
 
       - run: aws s3 sync ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
-      - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
-
-      # - name: remove .html files extension
-      #  run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
-      
       - name: remove .html files extension
-        run: aws mv ${{ secrets.AWS_S3_BUCKET_NAME }}/*.html ${{ secrets.AWS_S3_BUCKET_NAME }}/*%%.html
+        run: for file in $(find ${{ secrets.AWS_S3_BUCKET_NAME }} -name "*.html"); do mv "$file" "${file%%.html}"; done
+      
+      - name: Set HTML Content-Type and Copy them
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!*.*]" --content-type "text/html" --acl public-read --delete 
+
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,7 +4,7 @@
 name: Depoly Portfolio Application to AWS S3 Bucket (Static Web)
 
 on:
-  push:
+  pull_request:
     # NOTE: `main` branch has rule of managing deploy portfolio app in my repo!
     branches: ['main']
 
@@ -49,10 +49,10 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync --content-type "text/html" ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.(jpg|png|svg|ico|mp4|webp)" --acl public-read --delete
+        run: aws s3 cp --content-type "text/html" ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.(jpg|png|svg|ico|mp4|webp)" --acl public-read --delete
 
       - name: Copy Other Assets
-        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300
+        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,10 +43,10 @@ jobs:
       - name: delete all files
         run: aws s3 rm ${{ secrets.AWS_S3_BUCKET_NAME }}/ --recursive
 
-      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
+      - run: aws s3 sync ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --include "*.html" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.html" --content-type "text/html" --acl public-read --delete 
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
       
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!.*]" --content-type "text/html" --acl public-read --delete 
+        run: aws s3 sync ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "[!\.]" --content-type "text/html" --acl public-read --delete 
 
       - name: Copy Other Assets
         run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" --metadata-directive REPLACE --cache-control max-age=600

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,16 +43,16 @@ jobs:
       - name: delete all files
         run: aws s3 rm ${{ secrets.AWS_S3_BUCKET_NAME }}/ --recursive
 
-      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/
+      - run: aws s3 cp ./out/_next/ ${{ secrets.AWS_S3_BUCKET_NAME }}/_next/ --recursive
 
       - name: remove .html files extension
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Set HTML Content-Type and Copy them
-        run: aws s3 cp --content-type "text/html" ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.(jpg|png|svg|ico|mp4|webp)" --acl public-read --delete
+        run: aws s3 cp ./out ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.(jpg|png|svg|ico|mp4|webp)" --content-type "text/html" --acl public-read --delete
 
       - name: Copy Other Assets
-        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300
+        run: aws s3 cp ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --recursive --exclude "*.*" --include "*.(jpg|png|svg|ico|mp4|webp)" --metadata-directive REPLACE --cache-control max-age=300
 
       - name: Invalidate Cache
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -52,7 +52,9 @@ jobs:
         run: for file in $(find ./out -name "*.html"); do mv "$file" "${file%%.html}"; done
 
       - name: Copy Other Assets
-        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" --include "**/*.(jpg|png|svg|ico|mp4|webp)*" --metadata-directive --recursive REPLACE --cache-control max-age=300
+        run: aws s3 sync ./out/ ${{ secrets.AWS_S3_BUCKET_NAME }} --exclude "*" \ 
+             --include "*.jpg" --include "*.png" --include "*.svg" --include "*.ico" --include "*.mp4" --include "*.webp" \
+             --metadata-directive --recursive REPLACE --cache-control max-age=300
 
       - name: Invalidate Cache
         run: |


### PR DESCRIPTION
## 🚀 설명

흠... 이상하다.
CDN에도 캐시 컨트롤을 수정했고, aws s3에도 캐시 컨트롤을 먹였는데 되지 않는다.
시행착오가 좀 걸릴 문제라 아예 별도로 PR을 파서 테스트 후 스쿼시 머지를 하려 한다.

---

### 해결 - AWS S3 CLI NOT SUPPORT UNIX REGEX EXPRESSION

엄청난 충격이었다.
몇 시간의 삽질의 원인은, `AWS S3`에서 일반적인 정규표현식 패턴을 지원하지 않는다는 것이었다.
따라서 몇 가지의 와일드카드나 패턴 심볼만 지원하는데, 이는 다음과 같다.

```md
*: Matches everything
?: Matches any single character
[sequence]: Matches any character in sequence
[!sequence]: Matches any character not in sequence
```

## 🔗 관련 이슈와 링크

> `github`에서 연동된 이슈라면 closes #`이슈 번호`의 형태로 입력해주세요! 머지 시 자동으로 닫혀요! 😉

## 🔥 논의해 볼 사항

> PR을 하면서 공유되어야 할 특이한 사항들이 있었을까요? 공유해봅시다!
> 예시) A의 로직이 바람직하나, 현재 리소스를 고려할 때 최선인 B로 구현했습니다. 괜찮을까요? 😭

## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
- [x] 현재 `pull_request`일 때 워크플로우가 동작합니다. `push`로 바꿔주세요!

https://stackoverflow.com/questions/36215713/how-to-use-aws-cli-to-only-copy-files-in-s3-bucket-that-match-a-given-string-pat