### PR TITLE
[🐛 Bugfix] 모바일에서 헤더가 제대로 반응형이 적용되지 않는 현상을 해결한다

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -4,7 +4,7 @@
 name: Depoly Portfolio Application to AWS S3 Bucket (Static Web)
 
 on:
-  pull_request:
+  push:
     # NOTE: `main` branch has rule of managing deploy portfolio app in my repo!
     branches: ['main']
 

--- a/components/Header/Base.tsx
+++ b/components/Header/Base.tsx
@@ -20,7 +20,7 @@ interface BasePropsInterface {
 function Base({ hidden }: BasePropsInterface) {
   const router = useRouter();
 
-  const Links = [
+  const links = [
     {
       name: 'HOME',
       url: '/',
@@ -81,7 +81,7 @@ function Base({ hidden }: BasePropsInterface) {
 
         <StyledBase.LinksContainer>
           <StyledBase.Links isOpened={isOpened}>
-            {Links.map((link) => (
+            {links.map((link) => (
               <StyledBase.LinkContainer
                 isOpened={isOpened}
                 isActive={new RegExp(`^${windowState.location?.pathname}$`).test(link.url)}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,7 +29,10 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   return (
     <>
       <Head>
-        <meta name="viewport" content="viewport-fit=cover" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.5, user-scalable=0"
+        />
       </Head>
       <RecoilRoot>
         <CustomThemeProvider>


### PR DESCRIPTION
## 🚀 설명

메타 태그를 설정하는 과정에서, 내가 `meta` 속성을 잘못 준 것이 원인이었다.
이를 해결했다.

### 해결한 결과

정상적으로 반응형으로 레이아웃이 생성된다.

<img width="407" alt="image" src="https://user-images.githubusercontent.com/78713176/206111423-37d15be7-774e-467b-a0c4-cfb911968d33.png">


## 🔗 관련 이슈와 링크

closes #118 

## 🔥 논의해 볼 사항

#117 을 올리면서 감격한 나머지 급하게 머지해서, 변경해야 할 사항을 업데이트하지 않았다.
워크플로우상에서 main 브랜치에서 push할 때 CD가 될 수 있도록 설정한다. 🥲

## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
