### PR TITLE
[✨ Enhancement] 헤더가 열려있을 시 바깥부분을 벗어나면 다시 최소화되도록 한다

### DIFF
--- a/components/Hamburger/Default.tsx
+++ b/components/Hamburger/Default.tsx
@@ -1,18 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { StyledHamburger } from './styles';
 
 interface HamburgerInterface {
   onClick: () => void;
   margin: string;
+  opened: boolean;
 }
-function Hamburger({ onClick, margin }: HamburgerInterface) {
+function Hamburger({ onClick, margin, opened }: HamburgerInterface) {
   const [isActive, setIsActive] = useState(false);
 
   const onButtonClick = () => {
     onClick();
     setIsActive((state) => !state);
   };
+
+  useEffect(() => {
+    setIsActive(() => opened);
+  }, [opened]);
 
   const arr = Array.from({ length: 3 }, (_, idx) => idx);
   return (

--- a/components/Header/Base.tsx
+++ b/components/Header/Base.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -8,37 +8,44 @@ import Scheme from '@components/Button/Scheme';
 import { Hamburger } from '@components/Hamburger';
 import IconLink from '@components/Link/IconLink';
 
+import useClickAway from '@hooks/useClickAway';
 import useWindow from '@hooks/useWindow';
 
 import { MY_GITHUB_URL, MY_TECH_BLOG_URL } from '@utils/constants';
 
 import { StyledBase } from './styles';
 
+const links = [
+  {
+    name: 'HOME',
+    url: '/',
+    thumbnail: '/pages/index.png',
+  },
+  {
+    name: 'ABOUT',
+    url: '/about',
+    thumbnail: '/pages/about.png',
+  },
+  {
+    name: 'EXPERIENCES & PROJECTS',
+    url: '/experiences-and-projects',
+    thumbnail: '/pages/experiences-and-skills.png',
+  },
+];
+
 interface BasePropsInterface {
   hidden?: boolean;
 }
+
 function Base({ hidden }: BasePropsInterface) {
   const router = useRouter();
 
-  const links = [
-    {
-      name: 'HOME',
-      url: '/',
-      thumbnail: '/pages/index.png',
-    },
-    {
-      name: 'ABOUT',
-      url: '/about',
-      thumbnail: '/pages/about.png',
-    },
-    {
-      name: 'EXPERIENCES & PROJECTS',
-      url: '/experiences-and-projects',
-      thumbnail: '/pages/experiences-and-skills.png',
-    },
-  ];
-
   const [isOpened, setIsOpened] = useState(false);
+
+  const headerRef = useRef(null);
+  useClickAway(headerRef, () => {
+    setIsOpened(() => false);
+  });
 
   useEffect(() => {
     const onBack = (e: KeyboardEventInit) => {
@@ -48,6 +55,7 @@ function Base({ hidden }: BasePropsInterface) {
     };
 
     window.addEventListener('keydown', onBack);
+
     return () => {
       window.removeEventListener('keydown', onBack);
     };
@@ -73,9 +81,13 @@ function Base({ hidden }: BasePropsInterface) {
   ];
 
   return (
-    <StyledBase.Container isOpened={isOpened} hidden={hidden}>
+    <StyledBase.Container isOpened={isOpened} hidden={hidden} ref={headerRef}>
       <StyledBase.Header isOpened={isOpened}>
-        <Hamburger onClick={() => setIsOpened((state) => !state)} margin="0 0 0 1rem" />
+        <Hamburger
+          onClick={() => setIsOpened((state) => !state)}
+          opened={isOpened}
+          margin="0 0 0 1rem"
+        />
 
         <StyledBase.Title isOpened={isOpened}>Portfolio</StyledBase.Title>
 

--- a/components/Header/styles.ts
+++ b/components/Header/styles.ts
@@ -58,14 +58,14 @@ export const StyledBase = {
     ${({ isOpened, theme }) =>
       isOpened &&
       css`
-        display: flex;
+        /* display: flex; */
         height: 10rem;
 
         @media screen and (max-width: ${theme.viewPort.tabletMax}) {
           height: 15rem;
         }
         @media screen and (max-width: ${theme.viewPort.mobileMax}) {
-          height: auto;
+          height: 360px;
         } ;
       `}
   `,

--- a/hooks/useClickAway.ts
+++ b/hooks/useClickAway.ts
@@ -1,0 +1,37 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+const events = ['mousedown', 'touchstart'];
+
+const useClickAway = <R extends Element, F extends Function>(ref: RefObject<R>, handler: F) => {
+  const savedHandler = useRef<Function>(handler);
+
+  useEffect(() => {
+    savedHandler.current = handler; // 핸들러 함수가 변하더라도 다시 지우고 이벤트를 추가시키지 않도록 함.
+  }, [handler]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const handleEvent = (e: any) => {
+      if (!element.contains(e.target)) {
+        savedHandler.current(e);
+      }
+    };
+
+    events.forEach((eventName) => {
+      document.body.addEventListener(eventName, handleEvent);
+    });
+
+    return () => {
+      events.forEach((eventName) => {
+        document.body.removeEventListener(eventName, handleEvent);
+      });
+    };
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [ref.current]);
+
+  return ref;
+};
+
+export default useClickAway;


### PR DESCRIPTION
## 🚀 설명

이제는 바깥쪽을 닫아도 헤더가 자동으로 닫히도록 했다!
이를 통해, 유저는 호기심에 헤더를 누르고 다른 일을 해도 귀찮게 x버튼을 클릭하지 않아도 된다 😉

### 시현 영상

https://user-images.githubusercontent.com/78713176/206121474-1a59943f-9d64-460e-8fe9-9ba59a038ef2.mov

헤더를 키보드로 하던, 다른 곳을 클릭하던 잘 된다!

### 모바일에서 헤더가 트랜지션되지 않는 현상 해결


모바일에서 트랜지션되지 않던 문제 역시 이번에 확인하며 해결했다.

https://user-images.githubusercontent.com/78713176/206124761-915f6332-60e9-443c-92bb-52b2b0eef7c8.mov


## 🔗 관련 이슈와 링크

closes #97
closes #92  

## 🔥 논의해 볼 사항

이를 해결하면서, #92 도 해결했다.

## 🔑 참고할 만한 소스

> 이 문제를 해결하는 데, 해당 문서의 도움을 많이 받았습니다! 공유해요 🎉 (첨부)

## ⚠️ 잠깐! 한 번 체크해주세요.

- [x] 베이스가 제대로 적용되었나요?
- [x] 코드의 변경사항은 원하는 대로 잘 되었는지 다시 한 번 살펴봐요!
